### PR TITLE
Configurable Name ID Format

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -199,7 +199,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             ->setProtocolBinding($this->getDefaultAssertionConsumerServiceBinding())
             ->setIssueInstant(new DateTime())
             ->setDestination($identityProviderConsumerService->getLocation())
-            ->setNameIDPolicy((new NameIDPolicy())->setFormat(SamlConstants::NAME_ID_FORMAT_PERSISTENT))
+            ->setNameIDPolicy((new NameIDPolicy())->setFormat($this->getNameIDFormat()))
             ->setIssuer(new Issuer($this->getServiceProviderEntityDescriptor()->getEntityID()))
             ->setAssertionConsumerServiceURL($this->getServiceProviderAssertionConsumerUrl());
 
@@ -348,7 +348,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
     public function getServiceProviderEntityDescriptor(): EntityDescriptor
     {
         $spSsoDescriptor = new SpSsoDescriptor();
-        $spSsoDescriptor->setWantAssertionsSigned(true)->addNameIDFormat(SamlConstants::NAME_ID_FORMAT_PERSISTENT);
+        $spSsoDescriptor->setWantAssertionsSigned(true)->addNameIDFormat($this->getNameIDFormat());
 
         foreach ([SamlConstants::BINDING_SAML2_HTTP_REDIRECT, SamlConstants::BINDING_SAML2_HTTP_POST] as $binding) {
             $acsRoute = $this->getAssertionConsumerServiceRoute();
@@ -698,6 +698,11 @@ class Provider extends AbstractProvider implements SocialiteProvider
         }
 
         return $cert->setData($data);
+    }
+
+    protected function getNameIDFormat(): string
+    {
+        return $this->getConfig('sp_name_id_format', SamlConstants::NAME_ID_FORMAT_PERSISTENT);
     }
 
     protected function getTokenUrl()

--- a/Provider.php
+++ b/Provider.php
@@ -171,6 +171,7 @@ class Provider extends AbstractProvider implements SocialiteProvider
             'sp_org_display_name',
             'sp_org_url',
             'sp_default_binding_method',
+            'sp_name_id_format',
             'idp_binding_method',
             'attribute_map',
         ];

--- a/Provider.php
+++ b/Provider.php
@@ -702,7 +702,12 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
     protected function getNameIDFormat(): string
     {
-        return $this->getConfig('sp_name_id_format', SamlConstants::NAME_ID_FORMAT_PERSISTENT);
+        $default = SamlConstants::NAME_ID_FORMAT_PERSISTENT;
+        $format = $this->getConfig('sp_name_id_format', $default);
+
+        return SamlConstants::isNameIdFormatValid($format)
+            ? $format
+            : $default;
     }
 
     protected function getTokenUrl()


### PR DESCRIPTION
While working on a project I came across an issue with the Name ID Format not being a match with the IDP's. I believe this is a valuable addition to the library to extend the configuration and add the ability to configure the `SamlConstants::NAME_ID_FORMAT_PERSISTENT` being used in the Provider class.

By default the value will continue to be the default `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent` value. But it also allows the developer to set a new config value (`sp_name_id_format`) which would then change the name format.

I added a getter method, `Provider::getNameIDFormat()`, which validates the configured name id, in case it is not valid, it returns the `SamlConstants::NAME_ID_FORMAT_PERSISTENT` by default. Then updated the two references to use the getter instead of the constant directly.