### PR TITLE
Add SP initiated logoutRequest, add RelayState in messageContext

### DIFF
--- a/Provider.php
+++ b/Provider.php
@@ -31,6 +31,7 @@ use LightSaml\Helper;
 use LightSaml\Model\Assertion\Assertion;
 use LightSaml\Model\Assertion\AttributeStatement;
 use LightSaml\Model\Assertion\Issuer;
+use LightSaml\Model\Assertion\NameID;
 use LightSaml\Model\Context\DeserializationContext;
 use LightSaml\Model\Context\SerializationContext;
 use LightSaml\Model\Metadata\AssertionConsumerService;
@@ -43,6 +44,7 @@ use LightSaml\Model\Metadata\Organization;
 use LightSaml\Model\Metadata\SingleLogoutService;
 use LightSaml\Model\Metadata\SpSsoDescriptor;
 use LightSaml\Model\Protocol\AuthnRequest;
+use LightSaml\Model\Protocol\LogoutRequest;
 use LightSaml\Model\Protocol\LogoutResponse;
 use LightSaml\Model\Protocol\NameIDPolicy;
 use LightSaml\Model\Protocol\SamlMessage;
@@ -207,6 +209,23 @@ class Provider extends AbstractProvider implements SocialiteProvider
         return $this->sendMessage($authnRequest, $identityProviderConsumerService->getBinding());
     }
 
+    public function logoutRequest(string $nameId): HttpFoundationResponse
+    {
+        $identityProviderConsumerService = $this->getIdentityProviderEntityDescriptor()
+                ->getFirstIdpSsoDescriptor()
+                ->getFirstSingleLogoutService();
+
+        $logoutRequest = new LogoutRequest;
+        $logoutRequest
+                ->setID(Helper::generateID())
+                ->setIssueInstant(new DateTime())
+                ->setDestination($identityProviderConsumerService->getLocation())
+                ->setIssuer(new Issuer($this->getServiceProviderEntityDescriptor()->getEntityID()))
+                ->setNameID(new NameID($nameId));
+
+        return $this->sendMessage($logoutRequest, SamlConstants::BINDING_SAML2_HTTP_REDIRECT);
+    }
+
     public function logoutResponse(): HttpFoundationResponse
     {
         $this->receive();
@@ -240,6 +259,11 @@ class Provider extends AbstractProvider implements SocialiteProvider
 
         $messageContext = new MessageContext();
         $messageContext->setMessage($message);
+
+        if (! empty(request()->filled('RelayState'))) {
+            $messageContext->getMessage()
+                    ->setRelayState(request('RelayState'));
+        }
 
         $binding = (new BindingFactory())->create($bindingType);
 


### PR DESCRIPTION
I created this PR because today I needed SAML Single Logout from Service Providers (SP) to Microsoft ADFS, so I added logoutRequest method to Providers class and added chance to specify RelayState in SAML messageContext.
Tested with MS Azure AD, both directions: SLO from IDP to SP and SP to IDP. Worked.